### PR TITLE
Implement prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bin": {
     "p-start": "scripts/start.sh",
     "p-install": "scripts/install.sh",
+    "p-prepare": "scripts/prepare.sh",
     "p-deploy": "scripts/deploy.sh",
     "p-util": "scripts/util.sh"
   }

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -122,19 +122,3 @@ function cloneFromGit {
   toDir=$3
   git clone $fromRemoteOrigin --branch $branch --single-branch $toDir
 }
-
-# Clone git repo from one directory into another. Takes three position arguments:
-# 1) the branch
-# 2) the pathable package
-# 2) the path
-function gitCloneBranch {
-  branch=${1-}
-  package=${2-}
-  packagePath=${3-}
-  currentPath=$PWD
-  mkdir $packagePath
-  cd $packagePath
-  git init
-  git remote add -t $branch -f origin https://git@github.com/pathable/$package.git
-  cd $currentPath
-}

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -1,6 +1,8 @@
 npmCommand="meteor npm"
 npmAddCommand="meteor npm install"
 
+RED='\033[0;31m'
+GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
@@ -51,6 +53,54 @@ function installNpm {
   fi
 
   cd $OLDPWD
+}
+
+# Is the context a Meteor app?
+function isApp {
+  [ -f ".meteor/packages" ]
+}
+
+# Is the context a Meteor app?
+function isPackage {
+  [ -f "package.js" ]
+}
+
+function existsLocalBranch {
+  branch_name=${1-}
+  existsLocally=$(git branch | grep "\b$branch_name$")
+  [ "$existsLocally" ]
+}
+
+function existsRemoteBranch {
+  branch_name=${1-}
+  existsRemotely=$(git branch -r | grep "\borigin/$branch_name$")
+  [ "$existsRemotely" ]
+}
+
+# Does the branch exist in the current git context?
+function existsBranch {
+  branch_name=${1-}
+  $(existsLocalBranch $branch_name) || $(existsRemoteBranch $branch_name)
+}
+
+# Get the ancestor branch
+function ancestorBranch {
+  current_branch=${1-}
+  echo $(git show-branch -a | grep '\*' | grep -v "$current_branch" | head -n1 |  sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//')
+}
+
+# Which is the current ancestor context branch?
+function currentAncestorBranch {
+  current_branch=${1-$(git rev-parse --abbrev-ref HEAD)}
+  if [ $current_branch == "development" ] || [ $current_branch == "master" ]; then
+    echo $current_branch
+  else
+    ancestor=$(ancestorBranch $current_branch)
+    while [ $ancestor != "development" ] && [ $ancestor != "master" ]; do
+      ancestor="$(ancestorBranch $ancestor)"
+    done
+    echo $ancestor
+  fi
 }
 
 # Pull latest from current branch. Takes one position argument:

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -11,17 +11,6 @@ packageDir=$METEOR_PACKAGE_DIRS
 currentPath=$PWD
 currentDir=${PWD##*/}
 
-# Get the branch to check out
-function getBranch {
-  branch=''
-  if existsBranch $checkoutBranch; then
-    branch=$checkoutBranch
-  else
-    branch=$ancestorBranch
-  fi
-  echo $branch
-}
-
 function prepare {
   package=${1-}
   pull=${2-}
@@ -91,10 +80,21 @@ done
 shift $((OPTIND-1))
 
 checkoutBranch=${1-development}
-ancestorBranch=${2-$(currentAncestorBranch)}
+fallbackBranch=${2-$(currentAncestorBranch)}
+
+# Get the branch to check out
+function getBranch {
+  branch=''
+  if existsBranch $checkoutBranch; then
+    branch=$checkoutBranch
+  else
+    branch=$fallbackBranch
+  fi
+  echo $branch
+}
 
 printf "${BLUE}branch: ${checkoutBranch}\n${NC}"
-printf "${BLUE}ancestor: ${ancestorBranch}\n${NC}"
+printf "${BLUE}fallback: ${fallbackBranch}\n${NC}"
 printf "\n"
 
 prepare $currentDir $pull

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -1,0 +1,105 @@
+#!/bin/bash -e
+
+. "node_modules/pathable-scripts/scripts/_env.sh"
+. "node_modules/pathable-scripts/scripts/_lib.sh"
+
+load_env "$HOME/.pathable-env"
+load_env "config/$environment/.env"
+
+packageDir=$METEOR_PACKAGE_DIRS
+
+currentPath=$PWD
+currentDir=${PWD##*/}
+
+# Get the branch to check out
+function getBranch {
+  branch=''
+  if existsBranch $checkoutBranch; then
+    branch=$checkoutBranch
+  else
+    branch=$ancestorBranch
+  fi
+  echo $branch
+}
+
+function prepare {
+  package=${1-}
+  pull=${2-}
+  git fetch
+  branch=$(getBranch)
+  printf "${BLUE}Preparing \""${package}\"" to \"${branch}\"...\n${NC}"
+  git checkout $branch
+  if [ "$pull" = true ]; then
+    if existsRemoteBranch $branch; then
+      if git status -uno | grep -qo "nothing to commit"; then
+        git pull
+      fi
+    fi
+  fi
+}
+
+function prepareDependencies {
+  package=${1-}
+  pull=${2-}
+  packagePath=$packageDir/$package
+  if [ ! -d "$packagePath" ]; then
+    branch=$(getBranch)
+    cloneFromGit https://git@github.com/pathable/$package.git $branch $packagePath
+  fi
+  cd $packagePath
+  prepare $package $pull
+  cd $currentPath
+}
+
+# Prepare app packages from a Meteor app
+function prepareAppDependencies {
+  pull=${1-}
+  while read -r line
+  do
+    package=$(echo ${line} | sed -n 's/\(pathable-*\)/\1/p')
+    if [ ! -z "$package" ]; then
+      prepareDependencies $package $pull
+    fi
+  done < '.meteor/packages'
+}
+
+# Prepare app packages from a Meteor app
+function preparePackageDependencies {
+  pull=${1-}
+  cat 'package.js' | grep "api.use([\'\"]pathable-\w*[\'\"]);" | sort | uniq | while read -r line
+  do
+    package=$(sed -n "s/^api.use([\'\"]\(pathable\-.*\)[\'\"]);$/\1/p" <<< "${line}")
+    if [ ! -z "$package" ]; then
+      prepareDependencies $package $pull
+    fi
+  done
+}
+
+function usage { echo "Usage: $0 [-p(ull)]" 1>&2; exit 1; }
+
+# parse optional parameters
+while getopts ":prc" opt; do
+  case $opt in
+    p)
+      pull=true
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+checkoutBranch=${1-development}
+ancestorBranch=${2-$(currentAncestorBranch)}
+
+printf "${BLUE}branch: ${checkoutBranch}\n${NC}"
+printf "${BLUE}ancestor: ${ancestorBranch}\n${NC}"
+printf "\n"
+
+prepare $currentDir $pull
+if isApp; then
+  prepareAppDependencies $pull
+elif isPackage; then
+  preparePackageDependencies $pull
+fi


### PR DESCRIPTION
Story: [#140227109](https://www.pivotaltracker.com/story/show/140227109)

The `p-prepare` script makes ready the git environment to work with a specific feature by checking out a given branch for the app or package being running and all Pathable's dependencies.

Besides, if a dependency is not on the `METEOR_PACKAGES_DIR` reference it will automatically clone it.

## How to use

`p-prepare [-p(ull)] [branch] [fallback]`

- `-p`. Pull new changes if there are not conflicts on the local branch.
- `branch`. The branch that you want to check out from the app/package and all dependent packages
- `fallback`. The alternative branch to check out when is not possible the first branch. By default, it detects automatically the git-flow ancestor (`master` or `development`) by checking the git branch tree on the git context where you execute.

## Next work
Story: [#138484141](https://www.pivotaltracker.com/story/show/138484141)

This script will be used for enabling CI to automatically check out the branches related of a new feature and execute the tests properly.
