### PR TITLE
Script for running in multiple places [#151226916]

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Scripts included in `node_modules/.bin` are:
 1. p-start
 2. p-install
 3. p-deploy
+4. p-for
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "p-install": "scripts/install.sh",
     "p-prepare": "scripts/prepare.sh",
     "p-deploy": "scripts/deploy.sh",
-    "p-util": "scripts/util.sh"
+    "p-util": "scripts/util.sh",
+    "p-for": "scripts/for.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pathable-scripts",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Scripts used to manage pathable applications.",
   "author": "Pathable, Inc.",
   "bin": {

--- a/scripts/for.sh
+++ b/scripts/for.sh
@@ -57,7 +57,7 @@ function shouldRun {
 
 target="$1"
 shift
-command="$@"
+command="'$*'"
 currentPath=$(pwd)
 
 for d in $rootDir/*

--- a/scripts/for.sh
+++ b/scripts/for.sh
@@ -30,6 +30,11 @@ function shouldRun {
   target="$1"
   dir="$2"
 
+  if [[ "$(basename $d)" == pathable-* ]]
+  then
+    return 1
+  fi
+
   if [ "$target" == "apps" ]; then
     if isAppDir "$dir"; then
       return 0

--- a/scripts/for.sh
+++ b/scripts/for.sh
@@ -1,0 +1,71 @@
+#!/bin/bash -e
+
+. "node_modules/pathable-scripts/scripts/_env.sh"
+. "node_modules/pathable-scripts/scripts/_lib.sh"
+
+load_env "$HOME/.pathable-env"
+load_env "config/$environment/.env"
+
+rootDir=$METEOR_PACKAGE_DIRS
+
+USAGE="Usage: npm run for <all/apps/packages/> command"
+
+function isAppDir {
+  result=$(find "$1" -maxdepth 1 -type d -name ".meteor")
+  if [[ -n $result ]]; then
+    return 0
+  fi
+  return 1
+}
+
+function isPackageDir {
+  result=$(find "$1" -maxdepth 1 -type f -name "package.js")
+  if [[ -n $result ]]; then
+    return 0
+  fi
+  return 1
+}
+
+function shouldRun {
+  target="$1"
+  dir="$2"
+
+  if [ "$target" == "apps" ]; then
+    if isAppDir "$dir"; then
+      return 0
+    else
+      return 1
+    fi
+  fi
+  if [ "$target" == "packages" ]; then
+    if isPackageDir "$dir"; then
+      return 0
+    else
+      return 1
+    fi
+  fi
+  if [ "$target" == "all" ]; then
+    if isAppDir "$dir" || isPackageDir "$dir"; then
+      return 0
+    else
+      return 1
+    fi
+  fi
+  echo $USAGE
+  return 1
+}
+
+target="$1"
+shift
+command="$@"
+currentPath=$(pwd)
+
+for d in $rootDir/*
+  do
+    if shouldRun $target "$d"; then
+      cd "$d"
+      printf "${BLUE}Running command in "$(basename $d)":\n"
+      eval $command
+    fi
+  done
+cd $currentPath

--- a/scripts/for.sh
+++ b/scripts/for.sh
@@ -60,12 +60,12 @@ shift
 command="'$*'"
 currentPath=$(pwd)
 
-for d in $rootDir/*
+for d in $rootDir*
   do
     if shouldRun $target "$d"; then
       cd "$d"
-      printf "${BLUE}Running command in "$(basename $d)":\n"
-      eval $command
+      printf "${BLUE}Running command in "$(basename $d)":\n${NC}"
+      eval "'$command'"
     fi
   done
 cd $currentPath

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,7 +43,7 @@ function run {
             rm -rf $packageLocalPath
             mkdir $packageLocalPath
           else
-            >&2 echo "$(tput setaf 1) You have a package installed in the $packageLocalPath directory. You may instead want to set PACKAGES_DIR and manage packages via git instead.$(tput setab 7)"
+            >&2 echo "$(tput setaf 1) You have a package installed in the $packageLocalPath directory. You may instead want to set METEOR_PACKAGES_DIR and manage packages via git instead.$(tput setab 7)"
           fi
         fi
 


### PR DESCRIPTION
Usage: `npm run for <all/apps/packages/> command`, *apps* runs it only in the applications repositories, *packages* in the packages ones, and *all* in both

There is an issue when passing commands having dashes, like `git checkout -b newbranch`, the dash gets swallowed by npm and it forwards `git checkout b` as the parameters. So in that case, its necesary to enter the command inside single quotes, like so:  `npm run for packages 'git checkout -b newbranch'`.

Besides this, i think it is a good idea adding a file for having command alisases, as @flippyhead suggested. For example, for printing the current branch in each repository right now we would have to do : `npm run for all 'git rev-parse --abbrev-ref HEAD'`, we could create an alias to just have to do `npm run for all print-branch`