### PR TITLE
Command aliases

### DIFF
--- a/config/command-aliases.cfg
+++ b/config/command-aliases.cfg
@@ -1,0 +1,2 @@
+print-branch=git rev-parse --abbrev-ref HEAD
+clean-local-branches=git branch --merged | egrep -v "(^\*|master|development)" | xargs git branch -d

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pathable-scripts",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Scripts used to manage pathable applications.",
   "author": "Pathable, Inc.",
   "bin": {

--- a/scripts/for.sh
+++ b/scripts/for.sh
@@ -8,8 +8,8 @@ load_env "config/$environment/.env"
 
 rootDir=$METEOR_PACKAGE_DIRS
 
-USAGE="Usage: npm run for <all/apps/packages/> command\n"
-HELP="To get a list of available command aliases: npm run for --help\n"
+USAGE="Usage: npm run for <all/apps/packages/> command"
+HELP="To get a list of available command aliases: npm run for commands"
 
 function isAppDir {
   result=$(find "$1" -maxdepth 1 -type d -name ".meteor")
@@ -57,13 +57,13 @@ function shouldRun {
       return 1
     fi
   fi
-  echo -e "$USAGE"
-  echo -e "$HELP"
+  echo "$USAGE"
+  echo "$HELP"
   return 1
 }
 
 function getHelp {
-  echo "$USAGE"
+  echo "$USAGE\n"
   echo "Available command aliases:\n"
   IFS="="
   while read -r name value

--- a/scripts/for.sh
+++ b/scripts/for.sh
@@ -89,7 +89,7 @@ shift
 command="'$*'"
 currentPath=$(pwd)
 
-if [ $target == "help" ] || [ $target == "-help" ] || [ $target == "--help" ]; then
+if [ $target == "help" ] || [ $target == "commands" ]; then
   echo -e $(getHelp)
   exit
 fi

--- a/scripts/for.sh
+++ b/scripts/for.sh
@@ -8,7 +8,8 @@ load_env "config/$environment/.env"
 
 rootDir=$METEOR_PACKAGE_DIRS
 
-USAGE="Usage: npm run for <all/apps/packages/> command"
+USAGE="Usage: npm run for <all/apps/packages/> command\n"
+HELP="To get a list of available command aliases: npm run for --help\n"
 
 function isAppDir {
   result=$(find "$1" -maxdepth 1 -type d -name ".meteor")
@@ -56,14 +57,47 @@ function shouldRun {
       return 1
     fi
   fi
-  echo $USAGE
+  echo -e "$USAGE"
+  echo -e "$HELP"
   return 1
+}
+
+function getHelp {
+  echo "$USAGE"
+  echo "Available command aliases:\n"
+  IFS="="
+  while read -r name value
+  do
+    echo "${BLUE}${name} : ${NC}${value}\n"
+  done < "node_modules/pathable-scripts/scripts/config/command-aliases.cfg"
+}
+
+function getAliasCommand {
+  command="$1"
+  IFS="="
+  while read -r name value
+  do
+    if [ "$command" == "'$name'" ]; then
+      echo "'${value}'"
+      return 0
+    fi
+  done < "node_modules/pathable-scripts/scripts/config/command-aliases.cfg"
 }
 
 target="$1"
 shift
 command="'$*'"
 currentPath=$(pwd)
+
+if [ $target == "help" ] || [ $target == "-help" ] || [ $target == "--help" ]; then
+  echo -e $(getHelp)
+  exit
+fi
+
+aliasCommand=$(getAliasCommand "$command")
+if [ -n "${aliasCommand}" ]; then
+  command="$aliasCommand"
+fi
 
 for d in $rootDir*
   do


### PR DESCRIPTION
`npm run for help` or `npm run for commands` will print all the aliases available (`-help` or `--help` doesn't work because it gets used by npm)

For example, running `npm run for all print-branch` results in:

```
horacio@horacio-mint ~/git/pathable/pathable-admin $ npm run for all print-branch

> pathable-admin@0.0.1 for /home/horacio/git/pathable/pathable-admin
> p-for "all" "print-branch"

Running command in pathable-admin:
development
Running command in pathable-api:
development
Running command in pathable-app:
development
Running command in pathable-collection2-core:
development
Running command in pathable-collections:
development
Running command in pathable-global-styles:
development
Running command in pathable-htmltostring:
master
Running command in pathable-jobs:
development
Running command in pathable-mailer:
ci-test
Running command in pathable-schema:
development
Running command in pathable-styles:
development
Running command in pathable-supervisor:
fix/validate-account-slug
Running command in pathable-ui:
development
Running command in pathable-utilities:
development
Running command in pathable-vendor:
development
```